### PR TITLE
Update gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Metrics/LineLength:
 RSpec/ExampleLength:
   Max: 10
 
+RSpec/NamedSubject:
+  Enabled: false
+
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
   gem 'byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'coderay', require: false # Syntax highlighting for RSpec failures
   gem 'eslint-rails' # Ensures consistent JavaScript style
-  gem 'mutant-rspec', git: 'https://github.com/mbj/mutant.git', ref: 'cfc09e9', require: false # Mutation testing tool
+  gem 'mutant-rspec', require: false # Mutation testing tool
   gem 'rspec-rails' # Test framework
   gem 'rubocop' # Ensures consistent Ruby style
   gem 'rubocop-rspec', require: false # Ensures consistent RSpec style

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,4 @@
 GIT
-  remote: https://github.com/mbj/mutant.git
-  revision: cfc09e921c4ecf6ea903effb4ddd581d4ad8ea22
-  ref: cfc09e9
-  specs:
-    mutant (0.8.11)
-      abstract_type (~> 0.0.7)
-      adamantium (~> 0.2.0)
-      anima (~> 0.3.0)
-      ast (~> 2.2)
-      concord (~> 0.1.5)
-      diff-lcs (~> 1.2)
-      equalizer (~> 0.0.9)
-      ice_nine (~> 0.11.1)
-      memoizable (~> 0.4.2)
-      morpher (~> 0.2.6)
-      parallel (~> 1.3)
-      parser (~> 2.3.0, >= 2.3.0.2)
-      procto (~> 0.0.2)
-      unparser (~> 0.2.5)
-    mutant-rspec (0.8.11)
-      mutant (~> 0.8.11)
-      rspec-core (>= 3.4.0, < 3.6.0)
-
-GIT
   remote: https://github.com/rails/sass-rails.git
   revision: dfbcc6a53653d8908007e26324a0f299f026ec4f
   ref: dfbcc6a
@@ -187,6 +163,25 @@ GEM
       procto (~> 0.0.2)
     multi_json (1.12.1)
     multipart-post (2.0.0)
+    mutant (0.8.11)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.0)
+      ast (~> 2.2)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.2)
+      equalizer (~> 0.0.9)
+      ice_nine (~> 0.11.1)
+      memoizable (~> 0.4.2)
+      morpher (~> 0.2.6)
+      parallel (~> 1.3)
+      parser (~> 2.3.0, >= 2.3.0.2)
+      procto (~> 0.0.2)
+      regexp_parser (~> 0.3.6)
+      unparser (~> 0.2.5)
+    mutant-rspec (0.8.11)
+      mutant (~> 0.8.11)
+      rspec-core (>= 3.4.0, < 3.6.0)
     nenv (0.3.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
@@ -245,6 +240,7 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redis (3.3.1)
+    regexp_parser (0.3.6)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -272,8 +268,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.5.1)
-      rubocop (>= 0.41.2)
+    rubocop-rspec (1.5.3)
+      rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
     ruby_dep (1.3.1)
     ruby_identicon (0.0.5)
@@ -369,7 +365,7 @@ DEPENDENCIES
   guard
   guard-livereload
   listen
-  mutant-rspec!
+  mutant-rspec
   normalize-rails
   pg
   puma


### PR DESCRIPTION
* rubocop-rspec 1.5.1 → 1.5.3
[changelog](https://github.com/nevir/rubocop-rspec/blob/master/CHANGELOG.md#153-2016-08-02)