### PR TITLE
CharacterUpdaterJob: Handle ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/character_updater_job.rb
+++ b/app/jobs/character_updater_job.rb
@@ -2,18 +2,23 @@
 
 # Wraps {CharacterUpdater} and {CharacterUpdateBroadcaster} in a background job
 class CharacterUpdaterJob < ApplicationJob
+  rescue_from ActiveJob::DeserializationError, with: :log_error
+  rescue_from Armory::ServerError, with: :log_error
+
   # @param character [Character] character to check for updates
   # @return [void]
   def perform(character)
     broadcast(update(character), character.updated_at)
-  rescue Armory::ServerError => e
-    Rails.logger.warn "#{self.class} #{e.inspect}"
   end
 
   private
 
   def broadcast(*args)
     CharacterUpdateBroadcaster.call(*args)
+  end
+
+  def log_error(e)
+    Rails.logger.warn "#{self.class} #{e.inspect}"
   end
 
   def update(*args)

--- a/spec/jobs/character_updater_job_spec.rb
+++ b/spec/jobs/character_updater_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CharacterUpdaterJob do
       character = instance_double('Character', updated_at: Time.current)
       expect(CharacterUpdater).to receive(:call).and_raise(Armory::ServerError)
 
-      expect { subject.perform(character) }.not_to raise_error
+      expect { described_class.perform_now(character) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
This occurs when multiple CharacterUpdaterJobs are enqueued and the first causes the character to be deleted.

In the next version of Rails this can be simplified by just using `discard_on`.