### PR TITLE
RankingQuery: Use row_number for pagination since we're already calculating rank

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -8,8 +8,7 @@ class CharactersController < ApplicationController
 
   def index
     @ranking = RankingQuery.call(
-      cursor: params[:after] || params[:before],
-      page_direction: page_direction,
+      page: page,
       per_page: per_page(25),
       realm: params[:realm],
       region: region
@@ -33,12 +32,6 @@ class CharactersController < ApplicationController
     [params[:page].to_i, 1].max
   end
   helper_method :page
-
-  # Pagination direction based on provided cursor
-  def page_direction
-    return :after if params[:after]
-    :before if params[:before]
-  end
 
   # Defaults/limits `per_page` param to `max`
   def per_page(max)

--- a/app/helpers/characters_helper.rb
+++ b/app/helpers/characters_helper.rb
@@ -25,16 +25,10 @@ module CharactersHelper
     link_to name, characters_path(*server_parts(character))
   end
 
-  # @param cursor [Integer] ID of last {Character} on ranking page
+  # @param page [Integer] page number of ranking page
   # @return [String] path to next ranking page
-  def next_ranking_path(cursor)
-    characters_path(*server_parts, after: cursor, per_page: params[:per_page])
-  end
-
-  # @param cursor [Integer] ID of first {Character} on ranking page
-  # @return [String] path to previous ranking page
-  def prev_ranking_path(cursor)
-    characters_path(*server_parts, before: cursor, per_page: params[:per_page])
+  def ranking_path(page)
+    characters_path(*server_parts, page: page, per_page: params[:per_page])
   end
 
   # @return [String, nil]

--- a/app/presenters/ranked_characters_presenter.rb
+++ b/app/presenters/ranked_characters_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class RankedCharactersPresenter < CollectionPresenter
-  delegate :canonical_url, :comments, to: :query
+  delegate :canonical_url, :comments, :page, to: :query
 
   # @param characters [Enumerable<Character>]
   # @param query [RankingQuery]
@@ -16,22 +16,12 @@ class RankedCharactersPresenter < CollectionPresenter
 
   # @return [Boolean]
   def first_page?
-    !collection.first || collection.first.rank == 1
+    query.page.eql?(1)
   end
 
   # @return [Boolean]
   def last_page?
-    collection.size < query.per_page
-  end
-
-  # @return [Integer, nil]
-  def next_cursor
-    collection.last&.id
-  end
-
-  # @return [Integer, nil]
-  def prev_cursor
-    collection.first&.id
+    collection.length < query.per_page
   end
 
   private

--- a/app/views/characters/index.html.erb
+++ b/app/views/characters/index.html.erb
@@ -36,13 +36,13 @@
   <ul class="Navigation">
     <% unless @ranking.first_page? %>
       <li class="Navigation-item">
-        <%= link_to t('page.prev'), prev_ranking_path(@ranking.prev_cursor), rel: 'prev' %>
+        <%= link_to t('page.prev'), ranking_path(@ranking.page - 1), rel: 'prev' %>
       </li>
     <% end %>
 
     <% unless @ranking.last_page? %>
       <li class="Navigation-item">
-        <%= link_to t('page.next'), next_ranking_path(@ranking.next_cursor), rel: 'next' %>
+        <%= link_to t('page.next'), ranking_path(@ranking.page + 1), rel: 'next' %>
       </li>
     <% end %>
   </ul>

--- a/spec/presenters/ranked_characters_presenter_spec.rb
+++ b/spec/presenters/ranked_characters_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RankedCharactersPresenter do
     ]
   end
 
-  let(:query) { instance_double('RankingQuery', per_page: 1, realm: nil) }
+  let(:query) { instance_double('RankingQuery', page: 1, per_page: 1, realm: nil) }
 
   describe '#extra_column_name' do
     it 'returns Guild for realm ranking' do
@@ -26,14 +26,11 @@ RSpec.describe RankedCharactersPresenter do
   end
 
   describe '#first_page?' do
-    # rubocop:disable RSpec/VerifiedDoubles
-    it 'returns true if first character is ranked 1' do
-      character = double(rank: 1)
-      subject = described_class.new([character], query)
+    it 'returns true if query page is 1' do
+      subject = described_class.new(characters, query)
 
       expect(subject.first_page?).to eq(true)
     end
-    # rubocop:enable RSpec/VerifiedDoubles
 
     it 'handles an empty collection' do
       expect(subject.first_page?).to eq(true)
@@ -49,22 +46,6 @@ RSpec.describe RankedCharactersPresenter do
       subject = described_class.new([instance_double('Character')], query)
 
       expect(subject.last_page?).to eq(false)
-    end
-  end
-
-  describe '#prev_cursor' do
-    it 'returns ID of first character' do
-      subject = described_class.new(characters, query)
-
-      expect(subject.prev_cursor).to eq(1)
-    end
-  end
-
-  describe '#next_cursor' do
-    it 'returns ID of last character' do
-      subject = described_class.new(characters, query)
-
-      expect(subject.next_cursor).to eq(2)
     end
   end
 end

--- a/spec/queries/ranking_query_spec.rb
+++ b/spec/queries/ranking_query_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RankingQuery do
     end
 
     it 'returns ranked characters' do
-      characters = described_class.call(region: 'world', per_page: 3)
+      characters = described_class.call(region: 'world', page: 1, per_page: 3)
 
       expect(characters.size).to eq(3)
 
@@ -27,7 +27,7 @@ RSpec.describe RankingQuery do
     end
 
     it 'returns characters ranked by region' do
-      characters = described_class.call(region: 'eu')
+      characters = described_class.call(region: 'eu', page: 1, per_page: 3)
 
       expect(characters.size).to eq(2)
 
@@ -40,7 +40,7 @@ RSpec.describe RankingQuery do
     end
 
     it 'returns characters ranked by realm' do
-      characters = described_class.call(region: 'eu', realm: 'shadowmoon')
+      characters = described_class.call(region: 'eu', realm: 'shadowmoon', page: 1, per_page: 3)
 
       expect(characters.size).to eq(2)
 


### PR DESCRIPTION
This is simpler and no less performant than the seek pagination method since we are already using the `rank` window function over the whole table. UX is arguably improved as well.