### PR TITLE
Use a comma delimiter for character scores

### DIFF
--- a/app/views/characters/_character.html.erb
+++ b/app/views/characters/_character.html.erb
@@ -20,7 +20,7 @@
 </header>
 
 <output class="CharacterInfo-score" <%= tid :score %>>
-  <%= character.score %>
+  <%= number_with_delimiter character.score %>
 </output>
 
 <table class="Ilvls">

--- a/spec/features/character_page_spec.rb
+++ b/spec/features/character_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Character page' do
     expect(character_page.guild_name).to eq('The Gentlemens Club')
     expect(character_page.faction).to eq('alliance')
 
-    expect(character_page.score).to eq(19_891)
+    expect(character_page.score).to eq('19,891')
     expect(character_page.min_ilvl).to eq(655)
     expect(character_page.avg_ilvl).to eq(681)
     expect(character_page.max_ilvl).to eq(795)

--- a/spec/support/pages/character_page.rb
+++ b/spec/support/pages/character_page.rb
@@ -3,13 +3,13 @@
 require_relative './page'
 
 class CharacterPage < Page
-  %i[avg_ilvl comments_count max_ilvl median_difference min_ilvl score].each do |key|
+  %i[avg_ilvl comments_count max_ilvl median_difference min_ilvl].each do |key|
     define_method key do
       find_tid(key).text.to_i
     end
   end
 
-  %i[guild_name rating realm].each do |key|
+  %i[guild_name rating realm score].each do |key|
     define_method key do
       find_tid(key).text
     end


### PR DESCRIPTION
I was on the site the other day and the larger scores felt like a lot. However, I'm not totally sold on the delimiter so you won't hurt my feelings if you decide to just close.

Some comparisons for you...

![screen shot 2017-05-02 at 10 20 28 pm](https://cloud.githubusercontent.com/assets/1026104/25648386/8282c09e-2f88-11e7-9fe3-84dd2d70e0a4.png)

![screen shot 2017-05-02 at 10 20 14 pm](https://cloud.githubusercontent.com/assets/1026104/25648388/86dd0654-2f88-11e7-9c3f-822a53234475.png)

![screen shot 2017-05-02 at 10 22 15 pm](https://cloud.githubusercontent.com/assets/1026104/25648394/8f4bb100-2f88-11e7-94bc-6a91a6952ca9.png)

![screen shot 2017-05-02 at 10 22 44 pm](https://cloud.githubusercontent.com/assets/1026104/25648391/8b8f7cea-2f88-11e7-9e9d-ba56aea0c8c6.png)


