### PR TITLE
RankingQuery: Filter characters with data from before the 8.0.1 ilvl squish

### DIFF
--- a/app/queries/ranking_query.rb
+++ b/app/queries/ranking_query.rb
@@ -28,6 +28,7 @@ class RankingQuery
     characters = ranked_characters
       .select(*fields)
       .where(filter_criteria)
+      .where.not('level = 110 AND max_ilvl > 265') # Outdated data from before 8.0.1 ilvl squish
       .order(score: :desc, name: :asc, realm: :asc)
       .limit(per_page)
 

--- a/spec/fabricators/character_fabricator.rb
+++ b/spec/fabricators/character_fabricator.rb
@@ -4,7 +4,7 @@ Fabricator(:character) do
   avg_ilvl { rand(1..700) }
   class_name { CLASSES.sample }
   faction { FACTIONS.sample }
-  level { rand(1..110) }
+  level { rand(1..120) }
   max_ilvl { rand(1..700) }
   min_ilvl { rand(1..700) }
   region { VALID_REGIONS_WITH_REALM.sample }

--- a/spec/features/ranking_page_spec.rb
+++ b/spec/features/ranking_page_spec.rb
@@ -10,9 +10,10 @@ RSpec.feature 'Ranking page' do
   end
 
   before do
-    Fabricate(:character, name: 'a', region: 'eu', realm: 'shadowmoon', score: 20_000)
-    b = Fabricate(:character, name: 'b', region: 'eu', realm: 'shadowmoon', score: 20_000)
-    top = Fabricate(:character, name: 'top', region: 'us', realm: 'illidan', score: 50_000)
+    # Levels need to be > 110 so they are not randomly filtered
+    Fabricate(:character, level: 111, name: 'a', region: 'eu', realm: 'shadowmoon', score: 20_000)
+    b = Fabricate(:character, level: 111, name: 'b', region: 'eu', realm: 'shadowmoon', score: 20_000)
+    top = Fabricate(:character, level: 111, name: 'top', region: 'us', realm: 'illidan', score: 50_000)
 
     Fabricate(
       :character,

--- a/spec/queries/ranking_query_spec.rb
+++ b/spec/queries/ranking_query_spec.rb
@@ -5,10 +5,11 @@ require 'rails_helper'
 RSpec.describe RankingQuery do
   describe '#call' do
     before do
-      Fabricate(:character, region: 'eu', realm: 'shadowmoon', score: 200, guild_name: 'g')
-      Fabricate(:character, region: 'eu', realm: 'shadowmoon', score: 200, guild_name: 'g')
-      Fabricate(:character, region: 'us', realm: 'shadowmoon', score: 300)
-      Fabricate(:character, region: 'us', realm: 'illidan', score: 500)
+      # Levels need to be > 110 so they are not randomly filtered
+      Fabricate(:character, level: 111, region: 'eu', realm: 'shadowmoon', score: 200, guild_name: 'g')
+      Fabricate(:character, level: 111, region: 'eu', realm: 'shadowmoon', score: 200, guild_name: 'g')
+      Fabricate(:character, level: 111, region: 'us', realm: 'shadowmoon', score: 300)
+      Fabricate(:character, level: 111, region: 'us', realm: 'illidan', score: 500)
     end
 
     it 'returns ranked characters' do
@@ -52,6 +53,15 @@ RSpec.describe RankingQuery do
       expect { characters[0].region }.to raise_error(ActiveModel::MissingAttributeError)
 
       expect(characters[1].rank).to eq(1)
+    end
+
+    it 'filters characters with data from before the 8.0.1 ilvl squish' do
+      Fabricate(:character, level: 110, max_ilvl: 265)
+      Fabricate(:character, level: 110, max_ilvl: 266)
+
+      characters = described_class.call(region: 'world', page: 1, per_page: 6)
+
+      expect(characters.size).to eq(5)
     end
   end
 end


### PR DESCRIPTION
Armory profiles don't update with the new squished ilvls from 8.0.1 until a character logs in, so we have a ton of characters in the rankings with outdated data. Hopefully all the Armory data will be updated at some point so we can remove this. If not we may need to expand the ranking index.