### PR TITLE
RankingQuery: Filter outdated data before ranks are generated

### DIFF
--- a/app/queries/ranking_query.rb
+++ b/app/queries/ranking_query.rb
@@ -28,7 +28,6 @@ class RankingQuery
     characters = ranked_characters
       .select(*fields)
       .where(filter_criteria)
-      .where.not('level = 110 AND max_ilvl > 265') # Outdated data from before 8.0.1 ilvl squish
       .order(score: :desc, name: :asc, realm: :asc)
       .limit(per_page)
 
@@ -95,6 +94,8 @@ class RankingQuery
           rank() OVER (#{ranking_partition} ORDER BY score DESC),
           row_number() OVER (#{ranking_partition} ORDER BY score DESC)
         FROM characters
+        -- Filter outdated data from before 8.0.1 ilvl squish
+        WHERE NOT (level < 111 AND max_ilvl > 265)
       ) AS characters
     SQL
   end

--- a/spec/features/ranking_page_spec.rb
+++ b/spec/features/ranking_page_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Ranking page' do
 
     Fabricate(
       :character,
+      level: 111,
       region: 'us',
       realm: 'shadowmoon',
       score: 30_000,

--- a/spec/queries/ranking_query_spec.rb
+++ b/spec/queries/ranking_query_spec.rb
@@ -56,12 +56,13 @@ RSpec.describe RankingQuery do
     end
 
     it 'filters characters with data from before the 8.0.1 ilvl squish' do
-      Fabricate(:character, level: 110, max_ilvl: 265)
-      Fabricate(:character, level: 110, max_ilvl: 266)
+      Fabricate(:character, level: 110, max_ilvl: 265, score: 1000)
+      Fabricate(:character, level: 90, max_ilvl: 266)
 
       characters = described_class.call(region: 'world', page: 1, per_page: 6)
 
       expect(characters.size).to eq(5)
+      expect(characters[0].rank).to eq(1)
     end
   end
 end


### PR DESCRIPTION
We need to filter the outdated data before ranks are generated and also filter outdated data for characters below level 110.